### PR TITLE
Fix map scope issues in strict mode

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -83,7 +83,7 @@ L.MapboxGL = L.Class.extend({
     },
 
     _animateZoom: function (e) {
-        var origin = e.origin.add(this._map._getMapPanePos()).subtract(map.getSize().divideBy(2));
+        var origin = e.origin.add(this._map._getMapPanePos()).subtract(this._map.getSize().divideBy(2));
         this._glMap.zoomTo(e.zoom - 1, {
             duration: 250,
             offset: [origin.x, origin.y],


### PR DESCRIPTION
Hi,
Running this code in strict mode in IE was broken, because map was accessed globally instead of using this._map. If you were lucky to have a "map" var in window just like in the example, it would work, but not in every case

Fabien
