### PR TITLE
Fix examples

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -32,7 +32,7 @@ L.marker([38.912753, -77.032194])
     .openPopup();
 
 var gl = L.mapboxGL({
-    token: token,
+    accessToken: token,
     style: 'https://www.mapbox.com/mapbox-gl-styles/styles/bright-v4.json'
 }).addTo(map);
 

--- a/examples/cluster.html
+++ b/examples/cluster.html
@@ -35,7 +35,7 @@ if (!token) {
 }
 
 var gl = L.mapboxGL({
-    token: token,
+    accessToken: token,
     style: 'https://www.mapbox.com/mapbox-gl-styles/styles/bright-v4.json'
 }).addTo(map);
 


### PR DESCRIPTION
The examples used options.token when the plugin was looking for options.accessToken.