### PR TITLE
Fix mapbox-gl rendering when panning the map

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -64,13 +64,7 @@ L.MapboxGL = L.Class.extend({
             topLeft = this._map.containerPointToLayerPoint([0, 0]);
 
         L.DomUtil.setPosition(container, topLeft);
-
-        if (gl.transform.width !== size.x || gl.transform.height !== size.y) {
-            container.style.width  = size.x + 'px';
-            container.style.height = size.y + 'px';
-            gl.resize();
-        }
-
+        
         var center = this._map.getCenter();
 
         // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
@@ -79,7 +73,14 @@ L.MapboxGL = L.Class.extend({
         var tr = gl.transform;
         tr.center = mapboxgl.LatLng.convert([center.lat, center.lng]);
         tr.zoom = this._map.getZoom() - 1;
-        gl.render();
+
+        if (gl.transform.width !== size.x || gl.transform.height !== size.y) {
+            container.style.width  = size.x + 'px';
+            container.style.height = size.y + 'px';
+            gl.resize();
+        } else {
+            gl.update();
+        }
     },
 
     _animateZoom: function (e) {


### PR DESCRIPTION
After this obvious fix, the lib was actually broken:
https://github.com/mapbox/mapbox-gl-leaflet/commit/b0eb35e87317f754211f6af43a0f3a7bbcc87ee9

See my comments, the resize() call that was happening every time called _move() which invalidates the styles and called render.
Then update() would do basically nothing.
With the fix, if the viewport wasn't resized, calling gl.render() resulted in nothing because styles were not invalidated so mapbox-gl was doing nothing.
Instead, this PR calls update() which invalidates the style and gets the render loop working when panning / zooming.

I am not sure if it enhances performances of the map when dragging, which still lags behind but it fixes the panning issues

Tested in IE11 with latest mapbox-gl 0.7.0

Fabien