### PR TITLE
Fix memory leak when removing layer

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -28,6 +28,8 @@ L.MapboxGL = L.Class.extend({
         map.getPanes().tilePane.removeChild(this._glContainer);
         map.off('zoomanim', this._animateZoom, this);
         map.off('move', this._update, this);
+        this._glMap.remove();
+        this._glMap = null;
     },
 
     addTo: function (map) {


### PR DESCRIPTION
Hello,

Using the profiler, I noticed a memory leak when adding and removing the mapbox-gl-js layer. Here are the 3 snapshots with these 3 steps:
- Init a leaflet map with a tile layer
- Replace the tile layer with the mapbox-gl-js layer
- Replace the mapbox-gl-js layer with the original layer

Here are the results with the current version:
![image](https://cloud.githubusercontent.com/assets/1240481/9774375/5ea7c878-5748-11e5-94c9-844d7ea53d41.png)

Here are the results after calling the remove() method onRemove:
![image](https://cloud.githubusercontent.com/assets/1240481/9774387/739f21a4-5748-11e5-9e31-f6a3d7af0981.png)

When not calling onRemove, workers and styles are still in memory, and the resize handler is preventing the browser from deallocating the RAM.

Fabien