### PR TITLE
allow GLMap to pan beyond min/max latitude

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -57,6 +57,8 @@ L.MapboxGL = L.Class.extend({
         });
 
         this._glMap = new mapboxgl.Map(options);
+        // allow GL base map to pan beyond min/max latitudes
+        this._glMap.transform.latRange = null;
     },
 
     _update: function () {


### PR DESCRIPTION
this is a small change to allow the GLMap to pan beyond min/max latitudes at low zoom levels.