### PR TITLE
Adds "experimental" flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Note: this tool is experimental and is not actively supported by Mapbox. For support, please open an issue in this repository.**
+
 ## Mapbox GL Leaflet
 
 [![build status](https://secure.travis-ci.org/mapbox/mapbox-gl-leaflet.png)](http://travis-ci.org/mapbox/mapbox-gl-leaflet)


### PR DESCRIPTION
Adds a note to the README reaffirming that Mapbox will not directly support this and support requests should come through the repo. cc @mourner @danswick 