### PR TITLE
Fix #47, allow any MapBox GL JS

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -5,12 +5,12 @@
     <style>#map { width: 800px; height: 600px; }</style>
 
     <!-- Leaflet -->
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v1.0.0-beta.2/leaflet.css" />
-    <script src="http://cdn.leafletjs.com/leaflet/v1.0.0-beta.2/leaflet.js"></script>
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v1.0.0/leaflet.css" />
+    <script src="http://cdn.leafletjs.com/leaflet/v1.0.0/leaflet.js"></script>
 
     <!-- Mapbox GL -->
-    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.2/mapbox-gl.css" rel='stylesheet' />
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.2/mapbox-gl.js"></script>
+    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.25.1/mapbox-gl.css" rel='stylesheet' />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.25.1/mapbox-gl.js"></script>
 </head>
 
 <body>

--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -1,31 +1,3 @@
-function throttle(fn, time, context) {
-    var lock, args, wrapperFn, later;
-
-    later = function () {
-        // reset lock and call if queued
-        lock = false;
-        if (args) {
-            wrapperFn.apply(context, args);
-            args = false;
-        }
-    };
-
-    wrapperFn = function () {
-        if (lock) {
-            // called too soon, queue to call later
-            args = arguments;
-
-        } else {
-            // call and lock until later
-            fn.apply(context, arguments);
-            setTimeout(later, time);
-            lock = true;
-        }
-    };
-
-    return wrapperFn;
-};
-
 L.MapboxGL = L.Layer.extend({
     options: {
       updateInterval: 32


### PR DESCRIPTION
@fnicollet this fixes https://github.com/mapbox/mapbox-gl-leaflet/issues/47. Thanks to @EreMaijala identifying the commit that broke this.

This also allows use of any MapBox GL JS version from 0.11.2.