### PR TITLE
add a project changelog and prep for 0.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [0.0.3] - 2017-04-18
+
+### Added
+
+- Improved support for older versions of `mapbox-gl-js`
+
+## [0.0.2] - 2017-03-08
+
+### Added
+- Introduced support for Leaflet `v1.0.x`
+
+## 0.7.0 - 2016-10-09
+
+- Compatibility release for Leaflet `v0.7.x`
+
+[Unreleased]: https://github.com/mapbox/mapbox-gl-leaflet/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/mapbox/mapbox-gl-leaflet/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/mapbox/mapbox-gl-leaflet/compare/v0.7.0...v0.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-leaflet",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "binding from mapbox gl to the leaflet api",
   "main": "leaflet-mapbox-gl.js",
   "directories": {
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/mapbox/mapbox-gl-leaflet",
   "devDependencies": {
+    "gh-release": "^2.2.1",
     "jshint": "~2.5.5"
   }
 }


### PR DESCRIPTION
to do:
- [ ] create a GitHub `v0.0.2` release (using bacf37f31f4daee536c8914de31af5e08dee23a4)
- [ ] merge this PR
- [ ] publish `v0.0.3` to GitHub _and_ npm (from `HEAD`)

if you're interested in automating the process of publishing releases, i could put together a PR that uses `gh-release` and a bash script to make it a one liner.
