### PR TITLE
support for 'pane' in constructor

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -87,7 +87,7 @@
                 L.DomEvent.off(this._map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
             }
 
-            map.getPanes().tilePane.removeChild(this._glContainer);
+            this.getPane().removeChild(this._glContainer);
             this._glMap.remove();
             this._glMap = null;
         },

--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -70,7 +70,7 @@
                 this._initContainer();
             }
 
-            map._panes.tilePane.appendChild(this._glContainer);
+            this.getPane().appendChild(this._glContainer);
 
             this._initGL();
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-leaflet/issues/67   The new layer will properly use the **pane** option in the constructor. This allows the ability to stack layers by pane.


