### PR TITLE
Implemented overlay padding

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -13,12 +13,12 @@
     </style>
 
     <!-- Leaflet -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
 
     <!-- Mapbox GL -->
-    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.1/mapbox-gl.css" rel='stylesheet' />
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.1/mapbox-gl.js"></script>
+    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.css" rel='stylesheet' />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.js"></script>
 
 </head>
 

--- a/examples/cluster.html
+++ b/examples/cluster.html
@@ -6,12 +6,12 @@
     <style>#map { width: 800px; height: 600px; }</style>
 
     <!-- Leaflet -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
 
     <!-- Mapbox GL -->
-    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.1/mapbox-gl.css" rel='stylesheet' />
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.1/mapbox-gl.js"></script>
+    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.css" rel='stylesheet' />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.js"></script>
 
     <!-- Leaflet.MarkerCluster -->
     <script src='https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.4/leaflet.markercluster.js'></script>


### PR DESCRIPTION
As you can see in this [example](https://jsfiddle.net/w8r/3qp1j9e6/), panning or zooming the map can produce very unpleasant flickering on around the canvas edges, something that is avoided in leaflet by using buffer tiles:
<img width="612" alt="Screenshot 2019-08-07 00 59 05" src="https://user-images.githubusercontent.com/26884/62583029-d04c6a80-b8ae-11e9-8433-e012ceffbd20.png">

This PR addresses that issue by introducing a relative padding around the overlay containing the mapbox canvas. The arbitrary value of the padding is `0.15`, somewhat close to the value used in the leaflet vector renderers for the same purpose.

You can see the result comparison here https://bl.ocks.org/w8r/26b4f1a6ff0785a71c290d798337689a (map on the left has the padding, map on the right doesn't)


It also bumps the libraries in the examples (there was a maximum call stack exception in the basic example, rooted somewhere in the transformation update in `mapbox-gl-js@0.35.x`)

I also took the liberty to remove the `throttle` function implementation, as it has been the part of leaflet API since v1.0.0 for about 3 years now.