### PR TITLE
Adds `interactive` option

### DIFF
--- a/API.md
+++ b/API.md
@@ -19,6 +19,6 @@ for the full range.
 Same behavior as `.addTo` on any Leaflet layer: this adds the layer to a given
 map or group.
 
-### `layer.mapboxMap()`
+### `layer.getMapboxMap()`
 
 Returns `mapbox-gl.Map` object.

--- a/API.md
+++ b/API.md
@@ -12,6 +12,7 @@ for the full range.
 | ---- | ---- | ---- |
 | accessToken | string | **Required**: a [Mapbox access token](https://www.mapbox.com/help/define-access-token/) to identify requests for map resources |
 | padding | number | [0.15] | Relative padding of the mapbox-gl layer to avoid the background flickering around the edges of the map |
+| interactive | boolean | [false] | Wheter or not to register the mouse and keyboard events on the mapbox-gl layer. Turn this on if you intend to use the mapbox-gl layer events. |
 
 ### `layer.addTo(map)`
 

--- a/API.md
+++ b/API.md
@@ -18,3 +18,7 @@ for the full range.
 
 Same behavior as `.addTo` on any Leaflet layer: this adds the layer to a given
 map or group.
+
+### `layer.mapboxMap()`
+
+Returns `mapbox-gl.Map` object.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ var gl = L.mapboxGL({
 ```
 Once you have created the leaflet layer, the mapbox-gl map object can be accessed using
 ```javascript
-gl._glMap...
+gl.getMapboxMap()....
 // add a source to the mapbox-gl layer
-gl._glMap.addSource({...})
+gl.getMapboxMap().addSource({...})
 ```
 
 ## Get your Mapbox token

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Create a mapbox account, then head to [https://www.mapbox.com/studio/](https://w
 
 [Cluster example](http://rawgit.com/mapbox/mapbox-gl-leaflet/master/examples/cluster.html)
 
+[Map events example](http://rawgit.com/mapbox/mapbox-gl-leaflet/master/examples/events.html)
+
 Code for these examples is hosted in the [examples folder](https://github.com/mapbox/mapbox-gl-leaflet/tree/master/examples)
 
 ## Installation
@@ -51,7 +53,7 @@ Add a script tag referencing mapbox-gl-leaflet after adding leaflet in your webs
 <link rel="stylesheet" href="leaflet.css" />
 <script src="leaflet.js"></script>
 <script src="leaflet-mapbox-gl.js"></script>
-	
+
 <!-- Mapbox GL -->
 <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.14.3/mapbox-gl.css' rel='stylesheet' />
 <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.14.3/mapbox-gl.js'></script>
@@ -62,7 +64,7 @@ You can also use Unpkg as a CDN using:
 ```
 
 ## Motivation
-This project makes it possible to easily add a mapbox-gl-js layer in your Leaflet map. When using mapbox-gl-leaflet, you won't be able to use some of the mapbox-gl-js features. 
+This project makes it possible to easily add a mapbox-gl-js layer in your Leaflet map. When using mapbox-gl-leaflet, you won't be able to use some of the mapbox-gl-js features.
 Here are the main differences between a "pure" mapbox-gl-js map and a Leaflet map using mapbox-gl-leaflet:
 - No rotation / bearing / pitch support
 - Slower performances: When using mapbox-gl-leaflet, mapbox-gl-js is set as not interactive. Leaflet receives the touch/mouse events and updates the mapbox-gl-js map behind the scenes. Because mapbox-gl-js doesn't redraw as fast as Leaflet, the map can seem slower.

--- a/examples/events.html
+++ b/examples/events.html
@@ -37,25 +37,26 @@
     style: 'https://raw.githubusercontent.com/osm2vectortiles/mapbox-gl-styles/master/styles/bright-v9-cdn.json',
     interactive: true
   }).addTo(leafletMap);
-  console.log(gl._glMap);
 
-  gl._glMap.on('load', () => {
+  var mapboxMap = gl.getMapboxMap();
+
+  mapboxMap.on('load', () => {
     console.log('MAPBOX map loaded');
 
     // let's see events on mapbox map
-    gl._glMap.on('mousemove', () => { console.log('MAPBOX mousemove') });
-    gl._glMap.on('mouseenter', () => { console.log('MAPBOX mouseenter') });
-    gl._glMap.on('mouseout', () => { console.log('MAPBOX mouseout') });
-    gl._glMap.on('mouseleave', () => { console.log('MAPBOX mouseleave') });
-    gl._glMap.on('mouseover', () => { console.log('MAPBOX mouseover') });
+    mapboxMap.on('mousemove', () => { console.log('MAPBOX mousemove') });
+    mapboxMap.on('mouseenter', () => { console.log('MAPBOX mouseenter') });
+    mapboxMap.on('mouseout', () => { console.log('MAPBOX mouseout') });
+    mapboxMap.on('mouseleave', () => { console.log('MAPBOX mouseleave') });
+    mapboxMap.on('mouseover', () => { console.log('MAPBOX mouseover') });
 
     // let's add some layer and fire events on it
 
-    gl._glMap.addSource('states', {
+    mapboxMap.addSource('states', {
       'type': 'geojson',
       'data': 'https://docs.mapbox.com/mapbox-gl-js/assets/us_states.geojson'
     });
-    gl._glMap.addLayer({
+    mapboxMap.addLayer({
       'id': 'state-fills',
       'type': 'fill',
       'source': 'states',
@@ -66,10 +67,10 @@
       }
     });
 
-    gl._glMap.on('mouseenter', 'state-fills', (e) => {console.log('state-fills mouseenter', e) });
-    gl._glMap.on('mousemove', 'state-fills', (e) => {console.log('state-fills mousemove', e) });
-    gl._glMap.on('mouseout', 'state-fills', (e) => {console.log('state-fills mouseout', e) });
-    gl._glMap.on('mouseleave', 'state-fills', (e) => {console.log('state-fills mouseleave', e) });
+    mapboxMap.on('mouseenter', 'state-fills', (e) => {console.log('state-fills mouseenter', e) });
+    mapboxMap.on('mousemove', 'state-fills', (e) => {console.log('state-fills mousemove', e) });
+    mapboxMap.on('mouseout', 'state-fills', (e) => {console.log('state-fills mouseout', e) });
+    mapboxMap.on('mouseleave', 'state-fills', (e) => {console.log('state-fills mouseleave', e) });
 
   });
 

--- a/examples/events.html
+++ b/examples/events.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGL</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      html, body, #map {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+
+    <!-- Leaflet -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
+
+    <!-- Mapbox GL -->
+    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.css" rel='stylesheet' />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.js"></script>
+  </head>
+  <body>
+  <div id="map"></div>
+  <script src="../leaflet-mapbox-gl.js"></script>
+  <script>
+  var leafletMap = L.map('map').setView([38.912753, -77.032194], 2);
+
+  L.marker([38.912753, -77.032194])
+    .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
+    .addTo(leafletMap)
+    .openPopup();
+
+  var gl = L.mapboxGL({
+    padding: 0.1,
+    accessToken: 'no-token',
+    style: 'https://raw.githubusercontent.com/osm2vectortiles/mapbox-gl-styles/master/styles/bright-v9-cdn.json',
+    interactive: true
+  }).addTo(leafletMap);
+  console.log(gl._glMap);
+
+  gl._glMap.on('load', () => {
+    console.log('MAPBOX map loaded');
+
+    // let's see events on mapbox map
+    gl._glMap.on('mousemove', () => { console.log('MAPBOX mousemove') });
+    gl._glMap.on('mouseenter', () => { console.log('MAPBOX mouseenter') });
+    gl._glMap.on('mouseout', () => { console.log('MAPBOX mouseout') });
+    gl._glMap.on('mouseleave', () => { console.log('MAPBOX mouseleave') });
+    gl._glMap.on('mouseover', () => { console.log('MAPBOX mouseover') });
+
+    // let's add some layer and fire events on it
+
+    gl._glMap.addSource('states', {
+      'type': 'geojson',
+      'data': 'https://docs.mapbox.com/mapbox-gl-js/assets/us_states.geojson'
+    });
+    gl._glMap.addLayer({
+      'id': 'state-fills',
+      'type': 'fill',
+      'source': 'states',
+      'layout': {},
+      'paint': {
+        'fill-color': '#627BC1',
+        'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 1, 0.5 ]
+      }
+    });
+
+    gl._glMap.on('mouseenter', 'state-fills', (e) => {console.log('state-fills mouseenter', e) });
+    gl._glMap.on('mousemove', 'state-fills', (e) => {console.log('state-fills mousemove', e) });
+    gl._glMap.on('mouseout', 'state-fills', (e) => {console.log('state-fills mouseout', e) });
+    gl._glMap.on('mouseleave', 'state-fills', (e) => {console.log('state-fills mouseleave', e) });
+
+  });
+
+  // now let's see on leaflet map events
+  // SPOILER: they are works
+  leafletMap.on('mousemove', () => { console.log('LEAFLET mousemove') });
+  leafletMap.on('mouseenter', () => { console.log('LEAFLET mouseenter') });
+  leafletMap.on('mouseout', () => { console.log('LEAFLET mouseout') });
+  leafletMap.on('mouseleave', () => { console.log('LEAFLET mouseleave') });
+  leafletMap.on('mouseover', () => { console.log('LEAFLET mouseover') });
+    </script>
+  </body>
+</html>

--- a/examples/overlay.html
+++ b/examples/overlay.html
@@ -1,0 +1,47 @@
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+  <!-- Leaflet -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
+
+  <!-- Mapbox GL -->
+  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.css" rel='stylesheet' />
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.js"></script>
+  <script src="../leaflet-mapbox-gl.js"></script>
+  <style>
+    html, body, #map {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+	<div id="map"></div>
+
+	<script>
+    var map = new L.Map('map');
+		var gl = L.mapboxGL({
+      accessToken: 'no-token',
+      style: 'https://raw.githubusercontent.com/osm2vectortiles/mapbox-gl-styles/master/styles/bright-v9-cdn.json'
+    }).addTo(map);
+
+		var	bounds = new L.LatLngBounds(
+			new L.LatLng(40.71222,-74.22655),
+			new L.LatLng(40.77394,-74.12544));
+		map.fitBounds(bounds);
+		var overlay = new L.ImageOverlay("https://www.lib.utexas.edu/maps/historical/newark_nj_1922.jpg", bounds, {
+			opacity: 0.5,
+			interactive: true,
+			attribution: '&copy; A.B.B Corp.'
+		});
+		map.addLayer(overlay);
+		overlay.on('dblclick',function (e) {
+			console.log('Double click on image.');
+		});
+	</script>
+</body>
+</html>

--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -15,7 +15,10 @@
             updateInterval: 32,
             // How much to extend the overlay view (relative to map size)
             // e.g. 0.15 would be 15% of map view in each direction
-            padding: 0.15
+            padding: 0.15,
+            // whether or not to register the mouse and keyboard
+            // events on the mapbox overlay
+            interactive: false
         },
 
         initialize: function (options) {
@@ -90,7 +93,6 @@
 
             var options = L.extend({}, this.options, {
                 container: this._glContainer,
-                interactive: false,
                 center: [center.lng, center.lat],
                 zoom: this._map.getZoom() - 1,
                 attributionControl: false
@@ -109,9 +111,11 @@
             }
 
             // treat child <canvas> element like L.ImageOverlay
-            L.DomUtil.addClass(this._glMap._actualCanvas, 'leaflet-image-layer');
-            L.DomUtil.addClass(this._glMap._actualCanvas, 'leaflet-zoom-animated');
-
+            var canvas = this._glMap._actualCanvas;
+            L.DomUtil.addClass(canvas, 'leaflet-image-layer');
+            L.DomUtil.addClass(canvas, 'leaflet-zoom-animated');
+            if (this.options.interactive) L.DomUtil.addClass(canvas, 'leaflet-interactive');
+            if (this.options.className) L.DomUtil.addClass(canvas, this.options.className);
         },
 
         _update: function (e) {

--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -71,6 +71,10 @@
             };
         },
 
+        getMapboxMap: function () {
+            return this._glMap;
+        },
+
         _getSize: function () {
             return this._map.getSize().multiplyBy(1 + this.options.padding * 2);
         },

--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -114,8 +114,12 @@
             var canvas = this._glMap._actualCanvas;
             L.DomUtil.addClass(canvas, 'leaflet-image-layer');
             L.DomUtil.addClass(canvas, 'leaflet-zoom-animated');
-            if (this.options.interactive) L.DomUtil.addClass(canvas, 'leaflet-interactive');
-            if (this.options.className) L.DomUtil.addClass(canvas, this.options.className);
+            if (this.options.interactive) {
+                L.DomUtil.addClass(canvas, 'leaflet-interactive');
+            }
+            if (this.options.className) {
+                L.DomUtil.addClass(canvas, this.options.className);
+            }
         },
 
         _update: function (e) {


### PR DESCRIPTION
 - fixes #101, 
 - added `interactive` option
 - added an example of handling `mapbox-gl` events
 - added a method to get the `mapbox-gl` map

Now, you can create `L.MapboxGL` layer that will handle the built-in events, too:

```js
var gl = L.mapboxGL({
    accessToken: 'no-token',
    interactive: true
  }).addTo(map);
var mapObject = gl.getMapboxMap();
mapObject.on('mouseenter', 'state-fills', (e) => {
  console.log('state-fills mouseenter', e)
});
```
