### PR TITLE
Preparing v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.9] - 2019-09-02
+
+## Added
+
+- Added `interactive` option to make `mapbox-gl` map events handling possible.
+- added public accessor to `mapbox-gl` map object
+
 ## [0.0.8] - 2019-08-07
 
 ## Added

--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -14,8 +14,8 @@
             options: {
             updateInterval: 32,
             // How much to extend the overlay view (relative to map size)
-            // e.g. 0.15 would be 15% of map view in each direction
-            padding: 0.15,
+            // e.g. 0.1 would be 10% of map view in each direction
+            padding: 0.1,
             // whether or not to register the mouse and keyboard
             // events on the mapbox overlay
             interactive: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-leaflet",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "binding from mapbox gl to the leaflet api",
   "main": "leaflet-mapbox-gl.js",
   "directories": {


### PR DESCRIPTION
- [x] docs
- [x] changelog
- [x] reduced default `padding` value (it was causing warnings on large screens)