### PR TITLE
Removed check for given accessToken because Mapbox GL JS works without!

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -26,8 +26,6 @@
 
             if (options.accessToken) {
                 mapboxgl.accessToken = options.accessToken;
-            } else {
-                throw new Error('You should provide a Mapbox GL access token as a token option.');
             }
 
             // setup throttling the update event when panning


### PR DESCRIPTION
I removed the check for a given access token in the options. Mapbox GL JS just works fine without if you want to use a self hosted solution.

Proof: 
https://github.com/mapbox/mapbox-gl-js/issues/8569
