### PR TITLE
Fix offset issue

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -229,15 +229,11 @@
         },
 
         _zoomEnd: function () {
-            var scale = this._map.getZoomScale(this._map.getZoom()),
-                offset = this._map._latLngToNewLayerPoint(
-                    this._map.getBounds().getNorthWest(),
-                    this._map.getZoom(),
-                    this._map.getCenter()
-                );
+            var scale = this._map.getZoomScale(this._map.getZoom());
 
             L.DomUtil.setTransform(
                 this._glMap._actualCanvas,
+                // https://github.com/mapbox/mapbox-gl-leaflet/pull/130
                 null,
                 scale
             );

--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -238,7 +238,7 @@
 
             L.DomUtil.setTransform(
                 this._glMap._actualCanvas,
-                offset.subtract(this._offset),
+                null,
                 scale
             );
 


### PR DESCRIPTION
## Problem
When a zoom level is low, Mapbox.js layer and mapbox-gl-leaflet layer offset mismatch happens.

## Reproduce step
1. Create map with leaflet or Mapbox.js with empty style
2. Add GeoJSON layer
3. Add Mapbox GL JS layer with mapbox-gl-leaflet and set street-v11 style
4. Zoom out until until offset happens

<img width="905" alt="issue" src="https://user-images.githubusercontent.com/13183117/99186412-69954c80-2793-11eb-85e7-7a6e7c8b4e7e.png">

[Here's](https://gist.github.com/OttyLab/50a8018c7028feac62cfd64f6cec1ece) the reproduce sample.

## Expected result
<img width="700" alt="expected" src="https://user-images.githubusercontent.com/13183117/99186504-0526bd00-2794-11eb-9fbd-8e29ce2b8809.png">


## Detail
When `map.transform.latRange` is `null` as this [code](https://github.com/mapbox/mapbox-gl-leaflet/blob/master/leaflet-mapbox-gl.js#L133), Mapbox GL JS automatically generate offset to keep the center coordinate as the image below shows. The blue area is Mapbox GL JS canvas and offset happens when `map.transform.latRange` is `null`. However, current code tries to [subtract the offset](https://github.com/mapbox/mapbox-gl-leaflet/blob/master/leaflet-mapbox-gl.js#L241) and causes this issue.

<img width="796" alt="gl" src="https://user-images.githubusercontent.com/13183117/99186587-b0377680-2794-11eb-841b-66c65139fb23.png">

GL JS sample code is [here](https://gist.github.com/OttyLab/f88cd84984c97636d4ab647558900c2b).


