### PR TITLE
remove unused variable and add code comment

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -229,15 +229,11 @@
         },
 
         _zoomEnd: function () {
-            var scale = this._map.getZoomScale(this._map.getZoom()),
-                offset = this._map._latLngToNewLayerPoint(
-                    this._map.getBounds().getNorthWest(),
-                    this._map.getZoom(),
-                    this._map.getCenter()
-                );
+            var scale = this._map.getZoomScale(this._map.getZoom());
 
             L.DomUtil.setTransform(
                 this._glMap._actualCanvas,
+                // https://github.com/mapbox/mapbox-gl-leaflet/pull/130
                 null,
                 scale
             );


### PR DESCRIPTION
just a few tweaks to:
* avoid declaring an `offset` if its not going to be used
* add a code comment for future excavators

if we wanted to be 100% safe we could instantiate a `0,0` point object and pass it through instead of relying on what [`Leaflet.DomUtil.setTransform()`](https://leafletjs.com/reference-1.7.1.html#domutil-settransform) currently does under the hood to compensate for missing/invalid input parameters, but I'm fine with what you've already proposed.