### PR TITLE
Fix offset issue when initial zoom level is low

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -131,6 +131,7 @@
 
             // allow GL base map to pan beyond min/max latitudes
             this._glMap.transform.latRange = null;
+            this._transformGL(this._glMap);
 
             if (this._glMap._canvas.canvas) {
                 // older versions of mapbox-gl surfaced the canvas differently
@@ -167,14 +168,7 @@
 
             L.DomUtil.setPosition(container, topLeft);
 
-            var center = this._map.getCenter();
-
-            // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
-            // calling setView directly causes sync issues because it uses requestAnimFrame
-
-            var tr = gl.transform;
-            tr.center = mapboxgl.LngLat.convert([center.lng, center.lat]);
-            tr.zoom = this._map.getZoom() - 1;
+            this._transformGL(gl);
 
             if (gl.transform.width !== size.x || gl.transform.height !== size.y) {
                 container.style.width  = size.x + 'px';
@@ -192,6 +186,17 @@
                     gl.update();
                 }
             }
+        },
+
+        _transformGL: function (gl) {
+            var center = this._map.getCenter();
+
+            // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
+            // calling setView directly causes sync issues because it uses requestAnimFrame
+
+            var tr = gl.transform;
+            tr.center = mapboxgl.LngLat.convert([center.lng, center.lat]);
+            tr.zoom = this._map.getZoom() - 1;
         },
 
         // update the map constantly during a pinch zoom


### PR DESCRIPTION
## Problem
When the initial zoom level is low, Mapbox.js layer and mapbox-gl-leaflet layer offset mismatch happens.

## Reproduce step
1. Create map with leaflet or Mapbox.js with empty style
2. Add GeoJSON layer
3. Add Mapbox GL JS layer with mapbox-gl-leaflet and set street-v11 style
4. Set the initial zoom level low

<img width="809" alt="before" src="https://user-images.githubusercontent.com/13183117/99895545-ea8ca080-2ccb-11eb-9003-85f3dc9be46c.png">

[Here's](https://gist.github.com/OttyLab/50a8018c7028feac62cfd64f6cec1ece#file-index-mapboxjs-with-low-initial-zoom-html) the reproduce sample.

## Expected result
<img width="723" alt="expected" src="https://user-images.githubusercontent.com/13183117/99895596-625acb00-2ccc-11eb-89cf-f98138fa6296.png">

## Detail
By default, Mapbox GL JS [adjusts the center and zoom level](https://github.com/mapbox/mapbox-gl-js/blob/f0cc0159819617f59bbb5c3405a13a22f2f5c704/src/geo/transform.js#L642). After [this code](https://github.com/mapbox/mapbox-gl-leaflet/blob/v0.0.13/leaflet-mapbox-gl.js#L133) is executed, the adjustment is disabled. Therefore, center and zoom needs to be recalled after [this code](https://github.com/mapbox/mapbox-gl-leaflet/blob/v0.0.13/leaflet-mapbox-gl.js#L133) .


