### PR TITLE
Remember Mapbox GL map when removed to avoid creating a new SKU token on re-add

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -58,9 +58,6 @@
             }
             var paneName = this.getPaneName();
             map.getPane(paneName).removeChild(this._container);
-            
-            this._glMap.remove();
-            this._glMap = null;
         },
 
         getEvents: function () {
@@ -127,7 +124,11 @@
                 attributionControl: false
             });
 
-            this._glMap = new mapboxgl.Map(options);
+            if (!this._glMap) this._glMap = new mapboxgl.Map(options);
+            else {
+                this._glMap.setCenter(options.center);
+                this._glMap.setZoom(options.zoom);
+            }
 
             // allow GL base map to pan beyond min/max latitudes
             this._glMap.transform.latRange = null;


### PR DESCRIPTION
When re-adding a Mapbox GL layer to the Leaflet map (for example when using it in a [layers control](https://leafletjs.com/reference-1.7.1.html#control-layers)), `this._initGL();` is called again and recreates a Mapbox GL Map object from scratch `this._glMap = new mapboxgl.Map(options);`.
This means that a new SKU token is created each time the layer is added and it thus corresponds to separate map loads (which is unfortunate because [users are billed by map load](https://www.mapbox.com/pricing/#maploads)).
I updated the code to remember the Map object in `this._glMap` and only set the correct map center and zoom when the layer is re-added.