### PR TITLE
Apply minZoom and maxZoom options to layer

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -50,6 +50,8 @@
             if (map.options.zoomAnimation) {
                 L.DomEvent.on(map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
             }
+            
+            map._addZoomLimit(this);
         },
 
         onRemove: function (map) {


### PR DESCRIPTION
Currently, it is possible to zoom in infinitely on the maps even when maxZoom is specified.
I have now included the zoom limits with an existing L.Layer function when the layer is added.