### PR TITLE
Return from _update if layer has been removed

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -156,6 +156,9 @@
         },
 
         _update: function (e) {
+            if (!this._map) {
+                return;
+            }
             // update the offset so we can correct for it later when we zoom
             this._offset = this._map.containerPointToLayerPoint([0, 0]);
 


### PR DESCRIPTION
When the layer is removed, this._map is set to null, which makes the
_update function fail if called. Since there is nothing to update when
the layer is removed, just return in this case.

The reason _update may be called after the layer has been removed is
that it uses a throttle so if the throttle is called e.g. two times
right after each other, the second call will be delayed and the layer
can be removed in that time. This can happen if you add the layer and
then remove it right after.