### PR TITLE
Fixed mapbox-fl rendering when panning the map when the container is in percent

### DIFF
--- a/leaflet-mapbox-gl.js
+++ b/leaflet-mapbox-gl.js
@@ -173,9 +173,11 @@
 
             this._transformGL(gl);
 
-            if (gl.transform.width !== size.x || gl.transform.height !== size.y) {
-                container.style.width  = size.x + 'px';
-                container.style.height = size.y + 'px';
+            var x_round = Math.round(size.x), y_round = Math.round(size.y);
+
+            if (Math.round(gl.transform.width) !== x_round || Math.round(gl.transform.height) !== y_round) {
+                container.style.width  = x_round + 'px';
+                container.style.height = y_round + 'px';
                 if (gl._resize !== null && gl._resize !== undefined){
                     gl._resize();
                 } else {


### PR DESCRIPTION
Fix this issues https://github.com/mapbox/mapbox-gl-leaflet/issues/145
Example https://codepen.io/oranoran/pen/MWvWNmM
The bug occurs when the map container is set as a percent.
https://github.com/mapbox/mapbox-gl-leaflet/blob/master/leaflet-mapbox-gl.js#L176 - the values have different precision after the decimal point when compared, and resize is called incorrectly, not update